### PR TITLE
Require python3

### DIFF
--- a/gh-code-scanning
+++ b/gh-code-scanning
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import json


### PR DESCRIPTION
Running the extension with python 2.x gives a syntax error at line 39