### PR TITLE
Output the state and dismissal reason (if applicable) from the `alerts` sub-command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ A GitHub CLI extension for GitHub Code-Scanning!
 
 ### Dependencies
 
-- [`gh`](https://cli.github.com/)
 - Python (version 3.5 or higher)
 
 ### Installation

--- a/gh-code-scanning
+++ b/gh-code-scanning
@@ -207,7 +207,7 @@ def do_enable(args):
         )
 
     output = None if args.verbose else subprocess.DEVNULL
-    branch_name = 'mario-campos/gh-code-scanning'
+    branch_name = 'codeql-analysis'
     workflow_name = 'codeql-analysis.yml'
     workflow_dstdir = '.github/workflows'
     workflow_srcpath = os.path.join(os.path.dirname(__file__), workflow_name)

--- a/gh-code-scanning
+++ b/gh-code-scanning
@@ -170,7 +170,18 @@ class CodeScanningAlert(object):
 
         self.number     = obj['number']
         self.created_at = obj['created_at']
-        self.state      = obj['state']
+
+        if obj['state'] in {'open', 'closed', 'fixed'}:
+            self.state = obj['state']
+        elif obj['dismissed_reason'] == 'false positive':
+            self.state = 'dismissed:false-positive'
+        elif obj['dismissed_reason'] == "won't fix":
+            self.state = 'dismissed:wont-fix'
+        elif obj['dismissed_reason'] == 'used in tests':
+            self.state = 'dismissed:used-in-tests'
+        else:
+            self.state = 'dismissed:other'
+
         self.rule       = Rule(obj['rule']['name'], obj['rule']['id'], obj['rule'].get('severity', obj['rule'].get('security_severity_level')), obj['rule']['tags'])
         self.location   = Location(**obj['most_recent_instance']['location'])
 
@@ -308,7 +319,7 @@ def do_alerts(args):
             print(repo,
                   format(alert.number, '>4d'),
                   alert.created_at,
-                  format(alert.state, '>9s'),
+                  format(alert.state, '>24s'),
                   alert.rule.id,
                   '{}:{}'.format(alert.location.path, alert.location.start_line),
             )


### PR DESCRIPTION
Closes #4.