### PR TITLE
Use string comparison instead of integer

### DIFF
--- a/gh-code-scanning
+++ b/gh-code-scanning
@@ -150,9 +150,9 @@ class GithubRepository:
                 # Check for primary rate limits. GitHub indicates a primary rate limit through the use of
                 # a 403 status and a set of particular headers.
                 # https://docs.github.com/en/rest/overview/resources-in-the-rest-api#checking-your-rate-limit-status
-                if http_status == '403' and http_headers['X-Ratelimit-Remaining'] == 0:
-                    log.warning('GitHub primary rate limit reached; sleeping for %d seconds.', seconds)
-                    time.sleep(seconds)
+                if http_status == '403' and http_headers['X-Ratelimit-Remaining'] == '0':
+                    log.warning('GitHub primary rate limit reached; sleeping for %s seconds.', seconds)
+                    time.sleep(int(seconds))
                 
                 # GitHub may sometimes apply a secondary rate limit (to prevent abuse). Sometimes, it will tell
                 # us how to long to wait:
@@ -161,8 +161,8 @@ class GithubRepository:
                 #   >before making requests again.
                 # https://docs.github.com/en/rest/guides/best-practices-for-integrators#dealing-with-secondary-rate-limits
                 elif http_status == '403' and 'Retry-After' in http_headers:
-                    log.warning('GitHub secondary rate limit reached; sleeping for %d seconds.', http_headers['Retry-After'])
-                    time.sleep(http_headers['Retry-After'])
+                    log.warning('GitHub secondary rate limit reached; sleeping for %s seconds.', http_headers['Retry-After'])
+                    time.sleep(int(http_headers['Retry-After']))
                 
                 # GitHub may apply the secondary rate limit with little indication,
                 # other than a 403 status and an error message:


### PR DESCRIPTION
When I was doing some test runs of interpreting the GH CLI header data, I noticed that Python does not actually convert any datatypes and everything is a `str` type. 

A sample header payload is like this

```json
{'Access-Control-Allow-Origin': '*', 'Access-Control-Expose-Headers': 'ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset', 'Content-Security-Policy': "default-src 'none'", 'Date': 'Tue, 11 Oct 2022 23:25:32 GMT', 'Github-Authentication-Token-Expiration': '2023-08-01 07:00:00 UTC', 'Referrer-Policy': 'origin-when-cross-origin, strict-origin-when-cross-origin', 'Server': 'GitHub.com', 'Strict-Transport-Security': 'max-age=31536000; includeSubdomains; preload', 'Vary': 'Accept-Encoding, Accept, X-Requested-With', 'X-Accepted-Oauth-Scopes': 'repo', 'X-Content-Type-Options': 'nosniff', 'X-Frame-Options': 'deny', 'X-Github-Api-Version-Selected': '2022-08-09', 'X-Github-Media-Type': 'github.v3; format=json', 'X-Github-Request-Id': 'CCEE:9972:181CEB0:312E601:6345FB6B', 'X-Oauth-Scopes': 'admin:gpg_key, admin:public_key, admin:ssh_signing_key, codespace, delete:packages, gist, project, read:org, repo, user, workflow, write:discussion, write:packages', 'X-Ratelimit-Limit': '5000', 'X-Ratelimit-Remaining': '4998', 'X-Ratelimit-Reset': '1665534015', 'X-Ratelimit-Resource': 'core', 'X-Ratelimit-Used': '2'}
```
After parsing the header payload with the same codebase, I ran the following commands for verification

```bash
>>> dict_header['X-Ratelimit-Remaining'] == 4998
False
>>> dict_header['X-Ratelimit-Remaining'] == '4998'
True
```

This helped to confirm that the datatypes are actually still `str` types and all the comparisons to differentiate the primary and secondary rate limit would never be hit. 

I changed the comparisons so now they would do a string comparison and added an explicit type change to an `int` type so that it would be interpreted correctly by the sleep function.