### PR TITLE
Add support for Kotlin

### DIFF
--- a/gh-code-scanning
+++ b/gh-code-scanning
@@ -315,7 +315,7 @@ def do_enable(args):
         """
         if lang in {'C', 'C++'}:
             return 'cpp'
-        if lang == 'Java':
+        if lang in {'Java', 'Kotlin'}:
             return 'java'
         if lang == 'C#':
             return 'csharp'


### PR DESCRIPTION
This PR adds support for Kotlin. 

Kotlin uses the Java query pack so any repo that is identified to be using Kotlin should be classified as 'Java' for CodeQL purposes.